### PR TITLE
feat: add domain structure with entities, DTOs, mappers, and repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,35 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
 	<modelVersion>4.0.0</modelVersion>
+
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.5.0</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath/>
 	</parent>
+
 	<groupId>com.sartori</groupId>
 	<artifactId>food-order</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>food-order</name>
 	<description>Personal Java study project</description>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
+
 	<properties>
 		<java.version>17</java.version>
 	</properties>
+
 	<dependencies>
+		<!-- Spring Boot -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
@@ -43,60 +37,71 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-devtools</artifactId>
-			<scope>runtime</scope>
-			<optional>true</optional>
-		</dependency>
+		<!-- PostgreSQL -->
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+
+		<!-- Lombok -->
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<optional>true</optional>
+			<scope>provided</scope>
 		</dependency>
+
+		<!-- MapStruct -->
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>1.5.5.Final</version>
 		</dependency>
+
+		<!-- OpenAPI / Swagger -->
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>2.2.0</version>
 		</dependency>
+
+		<!-- Testes -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>
+			<!-- Compiler plugin com annotation processors -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.11.0</version>
 				<configuration>
+					<source>17</source>
+					<target>17</target>
 					<annotationProcessorPaths>
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
+							<version>1.18.30</version>
+						</path>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>1.5.5.Final</version>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
+
+			<!-- Spring Boot plugin -->
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<excludes>
-						<exclude>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</exclude>
-					</excludes>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>
-
 </project>

--- a/src/main/java/com/sartori/food_order/dto/client/ClientInputDTO.java
+++ b/src/main/java/com/sartori/food_order/dto/client/ClientInputDTO.java
@@ -1,0 +1,39 @@
+package com.sartori.food_order.dto.client;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.br.CPF;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "DTO used to create a new customer")
+public class ClientInputDTO {
+
+    @NotBlank(message = "{client.name.notblank}")
+    @Schema(description = "Customer's full name", example = "Eduardo Sartori", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String name;
+
+    @NotBlank(message = "{client.email.notblank}")
+    @Email(message = "{client.email.invalid}")
+    @Schema(description = "Valid customer email", example = "eduardo@example.com", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String email;
+
+    @NotBlank(message = "{client.cpf.notblank}")
+    @CPF(message = "{client.cpf.invalid}")
+    @Schema(description = "Valid customer CPF", example = "12345678901", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String cpf;
+
+    @NotNull(message = "{client.birthdate.notnull}")
+    @Past(message = "{client.birthdate.past}")
+    @Schema(description = "Customer's date of birth", example = "1999-01-01", requiredMode = Schema.RequiredMode.REQUIRED)
+    private LocalDate birthDate;
+}

--- a/src/main/java/com/sartori/food_order/dto/client/ClientOutputDTO.java
+++ b/src/main/java/com/sartori/food_order/dto/client/ClientOutputDTO.java
@@ -1,0 +1,19 @@
+package com.sartori.food_order.dto.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClientOutputDTO {
+
+    private Long id;
+    private String name;
+    private String email;
+    private String cpf;
+    private LocalDate birthDate;
+}

--- a/src/main/java/com/sartori/food_order/dto/order/OrderInputDTO.java
+++ b/src/main/java/com/sartori/food_order/dto/order/OrderInputDTO.java
@@ -1,0 +1,30 @@
+package com.sartori.food_order.dto.order;
+
+import com.sartori.food_order.dto.orderitem.OrderItemInputDTO;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "DTO used to create a new order")
+public class OrderInputDTO {
+
+    @NotNull(message = "{order.clientid.notnull}")
+    @Schema(description = "ID of the customer who placed the order", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Long clientId;
+
+    @Size(min = 1, message = "{order.items.size}")
+    @NotNull(message = "{order.items.notnull}")
+    @Schema(description = "Order Item List", requiredMode = Schema.RequiredMode.REQUIRED)
+    private List<@Valid OrderItemInputDTO> items;
+}

--- a/src/main/java/com/sartori/food_order/dto/order/OrderOutputDTO.java
+++ b/src/main/java/com/sartori/food_order/dto/order/OrderOutputDTO.java
@@ -1,0 +1,23 @@
+package com.sartori.food_order.dto.order;
+
+import com.sartori.food_order.dto.orderitem.OrderItemOutputDTO;
+import com.sartori.food_order.entity.OrderStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderOutputDTO {
+
+    private Long id;
+    private Long clientId;
+    private String clientName;
+    private LocalDateTime date;
+    private OrderStatus status;
+    private List<OrderItemOutputDTO> items;
+}

--- a/src/main/java/com/sartori/food_order/dto/orderitem/OrderItemInputDTO.java
+++ b/src/main/java/com/sartori/food_order/dto/orderitem/OrderItemInputDTO.java
@@ -1,0 +1,26 @@
+package com.sartori.food_order.dto.orderitem;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "DTO used to represent an order item on creation")
+public class OrderItemInputDTO {
+
+    @NotNull(message = "{orderitem.productid.notnull}")
+    @Schema(description = "Product ID", example = "3", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Long productId;
+
+    @NotNull(message = "{orderitem.quantity.notnull}")
+    @Min(value = 1, message = "{orderitem.quantity.min}")
+    @Schema(description = "Quantity of product in the order", example = "2", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Integer quantity;
+}

--- a/src/main/java/com/sartori/food_order/dto/orderitem/OrderItemOutputDTO.java
+++ b/src/main/java/com/sartori/food_order/dto/orderitem/OrderItemOutputDTO.java
@@ -1,0 +1,19 @@
+package com.sartori.food_order.dto.orderitem;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderItemOutputDTO {
+
+    private Long id;
+    private Long productId;
+    private String productName;
+    private Integer quantity;
+    private BigDecimal subtotal;
+}

--- a/src/main/java/com/sartori/food_order/dto/product/ProductInputDTO.java
+++ b/src/main/java/com/sartori/food_order/dto/product/ProductInputDTO.java
@@ -1,0 +1,32 @@
+package com.sartori.food_order.dto.product;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "DTO used to create a new product")
+public class ProductInputDTO {
+
+    @NotBlank(message = "{product.name.notblank}")
+    @Schema(description = "Product name", example = "Pizza Calabresa", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String name;
+
+    @Size(max = 255, message = "{product.description.size}")
+    @Schema(description = "Optional product description", example = "Pizza com calabresa e cebola caramelizada")
+    private String description;
+
+    @NotNull(message = "{product.price.notnull}")
+    @Positive(message = "{product.price.positive}")
+    @Schema(description = "Product price", example = "49.90", requiredMode = Schema.RequiredMode.REQUIRED)
+    private BigDecimal price;
+}

--- a/src/main/java/com/sartori/food_order/dto/product/ProductOutputDTO.java
+++ b/src/main/java/com/sartori/food_order/dto/product/ProductOutputDTO.java
@@ -1,0 +1,18 @@
+package com.sartori.food_order.dto.product;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductOutputDTO {
+
+    private Long id;
+    private String name;
+    private String description;
+    private BigDecimal price;
+}

--- a/src/main/java/com/sartori/food_order/entity/Client.java
+++ b/src/main/java/com/sartori/food_order/entity/Client.java
@@ -1,0 +1,31 @@
+package com.sartori.food_order.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "client")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Client {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(unique = true, nullable = false,length = 120)
+    private String email;
+
+    @Column(unique = true, nullable = false, length = 11)
+    private String cpf;
+
+    @Column(name = "birth_Date", nullable = false)
+    private LocalDate birthDate;
+}

--- a/src/main/java/com/sartori/food_order/entity/Order.java
+++ b/src/main/java/com/sartori/food_order/entity/Order.java
@@ -1,0 +1,34 @@
+package com.sartori.food_order.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Table(name = "customer_order")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "client_id")
+    private Client client;
+
+    @Column(nullable = false)
+    private LocalDateTime date;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false,  length = 20)
+    private OrderStatus status;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<OrderItem> items;
+}

--- a/src/main/java/com/sartori/food_order/entity/OrderItem.java
+++ b/src/main/java/com/sartori/food_order/entity/OrderItem.java
@@ -1,0 +1,33 @@
+package com.sartori.food_order.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "order_item")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @Column(nullable = false)
+    private Integer quantity;
+
+    @Column(nullable = false)
+    private BigDecimal subtotal;
+}

--- a/src/main/java/com/sartori/food_order/entity/OrderStatus.java
+++ b/src/main/java/com/sartori/food_order/entity/OrderStatus.java
@@ -1,0 +1,7 @@
+package com.sartori.food_order.entity;
+
+public enum OrderStatus {
+    NEW,
+    PROCESSED,
+    CANCELED
+}

--- a/src/main/java/com/sartori/food_order/entity/Product.java
+++ b/src/main/java/com/sartori/food_order/entity/Product.java
@@ -1,0 +1,28 @@
+package com.sartori.food_order.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "product")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(length = 255)
+    private String description;
+
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal price;
+}

--- a/src/main/java/com/sartori/food_order/mapper/ClientMapper.java
+++ b/src/main/java/com/sartori/food_order/mapper/ClientMapper.java
@@ -1,0 +1,12 @@
+package com.sartori.food_order.mapper;
+
+import com.sartori.food_order.dto.client.ClientInputDTO;
+import com.sartori.food_order.entity.Client;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface ClientMapper {
+
+    Client toEntity(ClientInputDTO dto);
+    ClientInputDTO toDTO(Client entity);
+}

--- a/src/main/java/com/sartori/food_order/mapper/OrderItemMapper.java
+++ b/src/main/java/com/sartori/food_order/mapper/OrderItemMapper.java
@@ -1,0 +1,17 @@
+package com.sartori.food_order.mapper;
+
+import com.sartori.food_order.dto.orderitem.OrderItemInputDTO;
+import com.sartori.food_order.entity.OrderItem;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface OrderItemMapper {
+
+    @Mapping(target = "product", ignore = true)
+    OrderItem toEntity(OrderItemInputDTO dto);
+
+    @Mapping(source = "product.id", target = "productId")
+    OrderItemInputDTO toDTO(OrderItem entity);
+}
+

--- a/src/main/java/com/sartori/food_order/mapper/OrderMapper.java
+++ b/src/main/java/com/sartori/food_order/mapper/OrderMapper.java
@@ -1,0 +1,16 @@
+package com.sartori.food_order.mapper;
+
+import com.sartori.food_order.dto.order.OrderInputDTO;
+import com.sartori.food_order.entity.Order;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring", uses = {OrderItemMapper.class})
+public interface OrderMapper {
+
+    @Mapping(target = "client", ignore = true)
+    Order toEntity(OrderInputDTO dto);
+
+    @Mapping(source = "client.id", target = "clientId")
+    OrderInputDTO toDTO(Order entity);
+}

--- a/src/main/java/com/sartori/food_order/mapper/ProductMapper.java
+++ b/src/main/java/com/sartori/food_order/mapper/ProductMapper.java
@@ -1,0 +1,12 @@
+package com.sartori.food_order.mapper;
+
+import com.sartori.food_order.dto.product.ProductInputDTO;
+import com.sartori.food_order.entity.Product;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface ProductMapper {
+
+    ProductInputDTO toEntity(Product entity);
+    Product toDTO(ProductInputDTO dto);
+}

--- a/src/main/java/com/sartori/food_order/repository/ClientRepository.java
+++ b/src/main/java/com/sartori/food_order/repository/ClientRepository.java
@@ -1,0 +1,12 @@
+package com.sartori.food_order.repository;
+
+import com.sartori.food_order.entity.Client;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ClientRepository extends JpaRepository<Client, Long> {
+    Optional<Client> findByEmail(String Email);
+}

--- a/src/main/java/com/sartori/food_order/repository/OrderRepository.java
+++ b/src/main/java/com/sartori/food_order/repository/OrderRepository.java
@@ -1,0 +1,9 @@
+package com.sartori.food_order.repository;
+
+import com.sartori.food_order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/com/sartori/food_order/repository/ProductRepository.java
+++ b/src/main/java/com/sartori/food_order/repository/ProductRepository.java
@@ -1,0 +1,9 @@
+package com.sartori.food_order.repository;
+
+import com.sartori.food_order.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -1,0 +1,20 @@
+client.name.notblank=The name is required.
+client.email.notblank=The email is required.
+client.email.invalid=The email provided is not valid.
+client.cpf.notblank=The CPF is required.
+client.cpf.invalid=The CPF provided is not valid.
+client.birthdate.notnull=The birth is required.
+client.birthdate.past=The birth must be in the past.
+
+product.name.notblank=The name is required.
+product.description.size=The description cannot exceed 255 characters.
+product.price.notnull=The price is required.
+product.price.positive=The price must be a positive value.
+
+order.clientid.notnull=The clientId is required.
+order.items.notnull=The items required.
+order.items.size=Must contain at least 1 item
+
+orderitem.productid.notnull=The productId is required.
+orderitem.quantity.notnull=The quantity is required.
+orderitem.quantity.min=Must contain at least 1 quantity


### PR DESCRIPTION
## What was done

Initial setup of the backend domain layer, including:

- Creation of entity classes (`Client`, `Product`, `Order`, `OrderItem`)
- Input and output DTOs for each entity
- Mapping configuration using MapStruct
- JPA repositories for database access

---

## Why

This is the foundation for the system's domain logic and data persistence. These components are necessary to support the service layer and allow us to implement business logic and data access operations in the next steps.

---

## Next steps

- Implement the service layer with business logic and validation
- Add controller classes to expose the API endpoints
- Write unit and integration tests
